### PR TITLE
feature/task-9-high-priority-connect-the-simulate-page-with-the-mock-web-socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
         "lint": "next lint",
         "build_websocket": "cd monty-mvp-mock-websocket/server && cmake . && cmake --build . && cd ../../",
         "run_websocket": "cd monty-mvp-mock-websocket/server/debug && server.exe && ../../"
-
     },
     "dependencies": {
         "@chakra-ui/react": "^1.8.7",
@@ -20,7 +19,8 @@
         "next": "12.1.4",
         "react": "18.0.0",
         "react-d3-library": "^1.1.8",
-        "react-dom": "18.0.0"
+        "react-dom": "18.0.0",
+        "react-use-websocket": "^3.0.0"
     },
     "devDependencies": {
         "@types/node": "17.0.23",

--- a/pages/onion/[id].tsx
+++ b/pages/onion/[id].tsx
@@ -379,7 +379,7 @@ const Onion: NextPage = (): JSX.Element => {
               Particle Type
             </ch.FormLabel>
 
-            <ch.Select placeholder="Select Particle" onChange={val => setParticle(val)}>
+            <ch.Select placeholder="Select Particle" onChange={e => setParticle(e.target.value)}>
               <option value="photon">
                 Photon
               </option>
@@ -400,7 +400,7 @@ const Onion: NextPage = (): JSX.Element => {
             <ch.FormLabel>
               Energy
             </ch.FormLabel>
-            <ch.Select placeholder="Select Initial Energy" onChange={val => setEnergy(val)}>
+            <ch.Select placeholder="Select Initial Energy" onChange={e => setEnergy(e.target.value)}>
               <option value="1">
                 1MeV
               </option>

--- a/pages/onion/simulate.tsx
+++ b/pages/onion/simulate.tsx
@@ -1,25 +1,70 @@
 import type { NextPage } from "next";
 import React from "react";
 import * as ch from "@chakra-ui/react";
-import { NextRouter, useRouter } from "next/router";
+import useWebSocket, { ReadyState } from 'react-use-websocket';
+import { useRouter } from 'next/router'
+
+
 
 
 
 
 const Onion: NextPage = (): JSX.Element => {
-  // All states for handling the form information.
+  const [socketUrl, _] = React.useState('ws://localhost:8080');
+  const router = useRouter()
+
+
+  const {
+    sendMessage,
+    lastMessage,
+    readyState,
+  } = useWebSocket(socketUrl);
+
+  const handleClickSendMessage = React.useCallback(
+    () => sendMessage(
+      JSON.stringify(
+        { "__MESSAGE__": "monty", ...router.query }
+        )
+    ),
+    []
+  );
+
+  handleClickSendMessage()
+
+  const connectionStatus = {
+    [ReadyState.CONNECTING]: 'Connecting',
+    [ReadyState.OPEN]: 'Open',
+    [ReadyState.CLOSING]: 'Closing',
+    [ReadyState.CLOSED]: 'Closed',
+    [ReadyState.UNINSTANTIATED]: 'Uninstantiated',
+  }[readyState];
+
+  const getLastMessage = (message: any) => {
+    if (readyState == ReadyState.CONNECTING) return "Connecting..."
+    if (readyState == ReadyState.CLOSING) return "Closing..."
+    if (readyState == ReadyState.CLOSED) return "CLOSED..."
+    if (readyState == ReadyState.UNINSTANTIATED) return "Uninstantiated..."
+
+    if (message == null) return "null"
+    let data = JSON.parse(message.data)
+    return data['__MESSAGE__']
+  }
+
   return <>
-  <ch.Flex w="100vw" h="100vh">
-    <ch.HStack w="full" h="full" align="center" >
-      <ch.VStack w="full" h="full" align="center" >
-        <ch.Spacer />
-        <ch.Spinner size='xl' />
-        <ch.Text>Getting your Monty Carlo instance... ;)</ch.Text>
-        <ch.Spacer />
-      </ch.VStack>
-    </ch.HStack>
-  </ch.Flex>
-</>
+    <ch.Flex w="100vw" h="100vh">
+      <ch.HStack w="full" h="full" align="center" >
+        <ch.VStack w="full" h="full" align="center" >
+          <ch.Spacer />
+          <ch.Spinner size='xl' />
+          <ch.Text>{lastMessage ? getLastMessage(lastMessage) : null}</ch.Text>
+          <ch.Spacer />
+          <pre>{JSON.stringify(router.query, null, 4)}</pre>
+
+          <ch.Spacer />
+        </ch.VStack>
+      </ch.HStack>
+    </ch.Flex>
+  </>
 };
 
 export default Onion;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,6 +4727,11 @@ react-style-singleton@^2.1.0:
     invariant "^2.2.4"
     tslib "^1.0.0"
 
+react-use-websocket@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-use-websocket/-/react-use-websocket-3.0.0.tgz#754cb8eea76f55d31c5676d4abe3e573bc2cea04"
+  integrity sha512-BInlbhXYrODBPKIplDAmI0J1VPM+1KhCLN09o+dzgQ8qMyrYs4t5kEYmCrTqyRuMTmpahylHFZWQXpfYyDkqOw==
+
 react@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.0.0.tgz#b468736d1f4a5891f38585ba8e8fb29f91c3cb96"


### PR DESCRIPTION
This PR integrates the mock websocket with the application. It introduces the following commands:

- `yarn build_websocket` - will call on the necessary `cmake` commands to compile the websocket server executable
- `yarn run_websocket` -  will start the websocket server on port 8080


![task-9-monty-mvp](https://user-images.githubusercontent.com/63464503/163795103-f3024501-60a9-4ef9-85fd-106a0b07fa7a.gif)